### PR TITLE
FEAT: (#10) v2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 # IDE
 .idea
 .vscode
+
+#Only Dev
+node_modules
+package.json
+package-lock.json
+.dev/
+gotar-rentcar-interface.iml

--- a/APIs/DTO/Request/OrderCancelRequest.ts
+++ b/APIs/DTO/Request/OrderCancelRequest.ts
@@ -1,0 +1,18 @@
+/**
+ * @interface OrderCancelRequestParam
+ * @description 예약 취소시 사용되는 Request Query DTO
+ */
+export interface OrderCancelRequestParam {
+  /**
+   * @type String
+   * @description 예약 취소할 주문의 고유 ID
+   * <br>
+   * 해당 주문건으로 생성된 예약 ID를 받는다
+   * OrderCreateResponse에서 받는 `globalApiOrderId`와 동일
+   * @nullable false
+   * @required true
+   * @example 'BLA1111'
+   * @default N/A
+   */
+  orderId: string;
+}

--- a/APIs/DTO/Request/OrderCreateRequest.ts
+++ b/APIs/DTO/Request/OrderCreateRequest.ts
@@ -1,11 +1,13 @@
+import { AvailableShopCombination } from '../../../Vehicle';
+
 /**
- * @interface OrderCreateRequest
- * @description 예약 생성시 사용되는 Request DTO
+ * @interface OrderCreateRequestBody
+ * @description 예약 생성시 사용되는 Request Body DTO
  * <br>
  * - 2.0기준으로 추가운전자에대한 대응이 안돼있음
  * - API에서 만약 추가운전자에대한 정보를 요구한다면 수정 필요
  */
-export default interface OrderCreateRequest {
+export default interface OrderCreateRequestBody {
   /**
    * @type String
    * @description carmore-common-api에서 식별하는 예약건의 고유 번호
@@ -25,6 +27,30 @@ export default interface OrderCreateRequest {
    * @default N/A
    */
   id: string;
+  /**
+   * @type String
+   * @description 예약할 차량의 대여업체
+   * <br>
+   * 원웨이예약이 아니라면 pickupShop과 returnShop은 항상 같다.
+   * 차량목록에서 받은 AvailableShopCombination에서 가능한 조합만 상세 조회가 가능하다.
+   * @nullable false
+   * @required true
+   * @example KL_12
+   * @default N/A
+   */
+  pickupShopId: string;
+  /**
+   * @type String
+   * @description 예약할 차량의 반납업체
+   * <br>
+   * 원웨이예약이 아니라면 pickupShop과 returnShop은 항상 같다.
+   * 차량목록에서 받은 AvailableShopCombination에서 가능한 조합만 상세 조회가 가능하다.
+   * @nullable false
+   * @required true
+   * @example KL_12
+   * @default N/A
+   */
+  returnShopId: string;
   /**
    * @type String
    * @description Currency (ISO 4217)
@@ -275,16 +301,7 @@ export interface OrderCreateRequestAddOn {
      * @default N/A
      */
     value: string;
-    /**
-     * @type Number
-     * @description 구매한 선택 가능한 옵션의 갯수
-     * @nullable false
-     * @required true
-     * @example 1
-     * @default 1
-     */
-    count: number;
-  };
+  }[];
   /**
    * @type Number
    * @description 구매한 부가서비스 갯수

--- a/APIs/DTO/Request/OrderDetailRequest.ts
+++ b/APIs/DTO/Request/OrderDetailRequest.ts
@@ -1,8 +1,8 @@
 /**
- * @interface OrderDetailRequest
- * @description 예약 상세 API Request DTO
+ * @interface OrderDetailRequestParam
+ * @description 예약 상세 API Request Param DTO
  */
-export default interface OrderDetailRequest {
+export interface OrderDetailRequestParam {
   /**
    * @type String
    * @description 외부 API에서 전달받은 예약건의 번호

--- a/APIs/DTO/Request/VehicleDetailRequest.ts
+++ b/APIs/DTO/Request/VehicleDetailRequest.ts
@@ -1,8 +1,8 @@
 /**
- * @interface VehicleDetailRequest
- * @description 차량 상세 조회시 사용되는 Request DTO
+ * @interface VehicleDetailRequestQuery
+ * @description 차량 상세 조회시 사용되는 Request Param DTO
  */
-export default interface VehicleDetailRequest {
+export interface VehicleDetailRequestParam {
   /**
    * @type String
    * @description 상세 조회할 차량의 ID (Vehicle._id와 동일한 값)
@@ -12,6 +12,13 @@ export default interface VehicleDetailRequest {
    * @default N/A
    */
   id: string;
+}
+
+/**
+ * @interface VehicleDetailRequestQuery
+ * @description 차량 상세 조회시 사용되는 Request Query DTO
+ */
+export interface VehicleDetailRequestQuery {
   /**
    * @type String
    * @description Currency (ISO 4217)
@@ -52,4 +59,28 @@ export default interface VehicleDetailRequest {
    * @default N/A
    */
   returnDateTime: string;
+  /**
+   * @type String
+   * @description 상세 조회할 차량의 대여업체
+   * <br>
+   * 원웨이예약이 아니라면 pickupShop과 returnShop은 항상 같다.
+   * 차량목록에서 받은 AvailableShopCombination에서 가능한 조합만 상세 조회가 가능하다.
+   * @nullable false
+   * @required true
+   * @example KL_12
+   * @default N/A
+   */
+  pickupShopId: string;
+  /**
+   * @type String
+   * @description 상세 조회할 차량의 반납업체
+   * <br>
+   * 원웨이예약이 아니라면 pickupShop과 returnShop은 항상 같다.
+   * 차량목록에서 받은 AvailableShopCombination에서 가능한 조합만 상세 조회가 가능하다.
+   * @nullable false
+   * @required true
+   * @example KL_12
+   * @default N/A
+   */
+  returnShopId: string;
 }

--- a/APIs/DTO/Request/VehicleListRequest.ts
+++ b/APIs/DTO/Request/VehicleListRequest.ts
@@ -1,8 +1,8 @@
 /**
- * @interface VehicleListRequest
- * @description 차량목록 조회시 사용되는 Request DTO
+ * @interface VehicleListRequestQuery
+ * @description 차량목록 조회시 사용되는 Request Query DTO
  */
-export default interface VehicleListRequest {
+export interface VehicleListRequestQuery {
   /**
    * @type String
    * @description Country Code (ISO 3166-1 alpha-2)
@@ -23,7 +23,6 @@ export default interface VehicleListRequest {
    * @default N/A
    */
   returnCountryCode: string;
-
   /**
    * @type String
    * @description Currency (ISO 4217)

--- a/APIs/DTO/Response/OrderCancelResponse.ts
+++ b/APIs/DTO/Response/OrderCancelResponse.ts
@@ -1,0 +1,7 @@
+import CommonResponse from './CommonResponse';
+
+/**
+ * @interface OrderCancelResponse
+ * @description 예약 취소 Response DTO
+ */
+export default interface OrderCancelResponse extends CommonResponse {}

--- a/Order.ts
+++ b/Order.ts
@@ -178,6 +178,18 @@ export default interface Order {
   price: OrderPrice;
   /**
    * @type Policy[]
+   * @description free text로 된 결제에 포함되는 기타 정보에 대한 설명들
+   * <br>
+   * 외부 API에서 제공하는 결제에 포함되는 기타 정보에대한 설명 따위가 Free Text로 돼있는 경우
+   * title, description 규격에 맞춰 제공해야한다.
+   * @nullable false
+   * @required false
+   * @example Policy[]
+   * @default []
+   */
+  reservationDescriptions: Policy[];
+  /**
+   * @type Policy[]
    * @description 예약된 차량의 대여규정 정보
    * @nullable false
    * @required false

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 # Global OTA RequestAndResponse (GOTAR)
-> 글로벌 OTA 렌터카 API들의 대한 통합 규격을 정의하는 Repository
+> 글로벌 OTA 렌터카 API들에 대한 통합 규격을 정의 하는 Repository
 
 ## APIs
-> 글로벌 OTA 렌터카 API들에대한 DTO Interface
+> 글로벌 OTA 렌터카 API들에 대한 DTO Interface
 
   - `${API Name}`Request
     - `${API Name}`의 요청 값에 대한 정의
@@ -13,10 +13,10 @@
 ## Interfaces
 > 글로벌 OTA 렌터카 API에 사용되는 Interface
 
-- `Required`: 아래 정의되는 `Interface`의 각 `Key`는 모두 필수 값입니다.
-  - 작업하는 API에서 Key에대한 Value값을 정의할 수 없다면 아래 기본값을 넣어야합니다. __(Nullable인경우 Null)__
+- `Required`: 아래 정의 되는 `Interface`의 각 `Key`는 모두 필수 값 입니다.
+  - 작업하는 API에서 Key에대한 Value 값을 정의할 수 없다면 아래 기본값을 사용해야 합니다. __(Nullable인경우 Null)__
   - 주석 내용 중 __`@required`: true__ 인 경우 기본값을 넣을 수 없는 `Key`입니다.
-  - 기본값을 할당할 수 없는 `Key`는 기본값을 상수로 만들어 할당해야합니다.
+  - 기본 값을 할당할 수 없는 `Key`는 기본 값을 상수로 만들어 할당 해야 합니다.
     - `String` : null or ''
     - `Number` : null or 0
     - `Boolean` : false
@@ -24,27 +24,27 @@
 
 ### Comment Component
   - `@type`
-    - String, Boolean등 Component에대한 타입
+    - String, Boolean등 Component들의 타입
   - `@description`
     - Component에대한 설명
   - `@nullable`
     - Null허용 여부
   - `@required`
-    - Interface에서 기본값이 불가능한 필수적으로 정의해야하는 값인지에대한 여부
+    - Interface에서 기본값 이 불가능 한 필수적 으로 정의해야 하는 값인지 에대한 여부
   - `@example`
-    - Component 예시값 (실제 값과 최대한 비슷하게), 열거 가능한 값인 경우 열거 가능한 값을 전부 작성.
+    - Component 예시값 (실제 값과 최대한 비슷 하게), 열거 가능한 값인 경우 열거 가능한 값을 전부 작성.
   - `@default`
-    - Component 기본값, 불가능한 경우 `N/A`
+    - Component 기본값, 불가능 한 경우 `N/A`
 
 ### Interface
   - [`Car`](Car.ts)
-    - 차종에대한 정의 (실제 판매되는 렌터카에대한 `차종` EX: `K5`등)
+    - 차종에 대한 정의 (실제 판매 되는 렌터카에 대한 `차종` EX: `K5`등)
 
   - [`Vehicle`](Vehicle.ts)
-    - 차량에대한 정의 (실제 판매되는 렌터카 상품)
+    - 차량에 대한 정의 (실제 판매 되는 렌터카 상품)
 
   - [`Affiliate`](Affiliate.ts)
-    - 업체에대한 정의
+    - 업체에 대한 정의
 
   - [`Vendor`](Vendor.ts)
     - `Budget`, `Avis`와 같은 업체 브랜드
@@ -56,24 +56,39 @@
     - `Vehicle`에대한 실제 주문 내용
 
   - `Reservation`
-    - `Carmore` 운영에 사용되는 예약에대한 `Interface`
+    - `Carmore` 운영에 사용 되는 예약에 대한 `Interface`
 
 ### APIs
-> Global API에서 필수적으로 제공해야하는 API
+> Global API에서 필수적 으로 제공 해야 하는 API
+
+  - `APIs Name`
+    - `APIs Description`
+    - `API Name`
+      - `Request` : 해당 API의 Request Query, Param, Body를 포함한 Typescript File
+      - `Response` : 해당 API의 Response를 Typescript File
+      - endPoint : 해당 API의 EndPoint 및  Http Method
 
   - `Vehicle`
-    - `차량 목록`, `차량 상세`를 제공해야 한다.
+    - `차량 목록`, `차량 상세`를 제공 해야 한다.
       - `차량 목록`
         - [Request](./APIs/DTO/Request/VehicleListRequest.ts)
         - [Response](./APIs/DTO/Response/VehicleListResponse.ts)
+        - endPoint : `GET` `/vehicles`
       - `차량 상세`
         - [Request](./APIs/DTO/Request/VehicleDetailRequest.ts)
         - [Response](./APIs/DTO/Response/VehicleDetailResponse.ts)
+        - endPoint : `GET` `/vehicles/:id`
   - `Order`
-    - `예약 생성`, `예약 상세`를 제공해야 한다.
+    - `예약 생성`, `예약 상세`, `예약 취소`를 제공 해야 한다.
       - `예약 생성`
         - [Request](./APIs/DTO/Request/OrderCreateRequest.ts)
         - [Response](./APIs/DTO/Response/OrderCreateResponse.ts)
+        - endPoint : `POST` `/orders`
       - `예약 상세`
         - [Request](./APIs/DTO/Request/OrderDetailRequest.ts)
         - [Response](./APIs/DTO/Response/OrderDetailResponse.ts)
+        - endPoint : `GET` `/orders/:id`
+      - `예약 취소`
+        - [Request](./APIs/DTO/Request/OrderCancelRequest.ts)
+        - [Response](./APIs/DTO/Response/OrderCancelResponse.ts)
+        - endPoint : `PATCH` `/orders/:id/cancelation`

--- a/Shop.ts
+++ b/Shop.ts
@@ -175,7 +175,7 @@ export default interface Shop {
    * @type ReturnShop
    * @description 반납 업체 정보
    * <br>
-   * 구조는 Shop 그 자체와 동일하다. 차량리스트에서는 해당 객체가 아예 없으며, 차량 상세, 예약 상세에서만 존재할 수 있다.
+   * 구조는 Shop의 Interface를 그대로 사용한다. 차량목록에서는 해당 객체가 아예 없으며, 차량 상세, 예약 상세에서만 존재할 수 있다.
    * @nullable false
    * @required true
    * @example ReturnShop
@@ -240,6 +240,8 @@ export interface OperationTime {
   /**
    * @type String
    * @description 운영 시작 시간
+   * <br>
+   * - 운영시작 시간과 종료시간이 모두 00:00이고, closeNextDay가 false는 휴무일이다.
    * @nullable false
    * @required true
    * @example 00:00
@@ -249,6 +251,7 @@ export interface OperationTime {
   /**
    * @type String
    * @description 운영 종료 시간
+   * 운영시작 시간과 종료시간이 모두 00:00이고, closeNextDay가 false는 휴무일이다.
    * @nullable false
    * @required true
    * @example 22:00
@@ -304,6 +307,8 @@ export interface SeasonalOperationTime {
   /**
    * @type String
    * @description 운영 시작 시간
+   * - 운영시작 시간과 종료시간이 모두 00:00이고, closeNextDay가 false는 휴무일이다.
+   * - 예시: startDate: 2022-01-01, endDate: 2022-01-01, open: 00:00, clsoe: 00:00은 2022-01-01, 01-01은 휴무라는 의미.
    * @nullable false
    * @required true
    * @example 00:00
@@ -313,6 +318,8 @@ export interface SeasonalOperationTime {
   /**
    * @type String
    * @description 운영 종료 시간
+   * - 운영시작 시간과 종료시간이 모두 00:00이고, closeNextDay가 false는 휴무일이다.
+   * - 예시: startDate: 2022-01-01, endDate: 2022-01-01, open: 00:00, clsoe: 00:00은 2022-01-01, 01-01은 휴무라는 의미.
    * @nullable false
    * @required true
    * @example 22:00
@@ -634,4 +641,11 @@ export interface ChargedTimePrice {
   amount: number;
 }
 
+/**
+ * @interface ReturnShop
+ * @description 반납업체
+ * <br>
+ * 차량목록 : 사용하지 않음
+ * 차량상세, 예약상세: 필수값
+ */
 export interface ReturnShop extends Omit<Shop, 'returnShop'> {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,14 @@
     "sourceMap": true,
     "baseUrl": "./",
     "incremental": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "plugins": [
+      {
+        "transform": "typia/lib/transform"
+      }
+    ],
+    "strictNullChecks": true,
+    "strict": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
- Hikari API로 생기는 변경점 추가
  - 대여-반납이 가능한 업체 조합 Key 추가 (`availableShopCombination`)
  	- 차량상세 및 예약생성시 업체 조합의 `pickupShopId, returnShopId` 사용
  - 보험에 정보성으로 사용하는 가격 Key추가
  	- prepaidPrice, payOnArrivalPrice
  - Vehicle.reservation에 가격 정보에대한 Key추가
    - `reservationDescriptions`

- 부가서비스 관련 수정사항 추가
	- Sicily, Hikari API 작업시 기능상 미비된 부분 추가됨

- API 문서 중 누락된 부분 추가 및 수정
	- Order Cancel 누락된 부분 추가
	- API Request 관련 Query, Param, Body 구분 추가 
