### PR TITLE
FEAT:(BACKENDDEV-1878) Affiliate 비필수 데이터 cancellationPolicies 규격 추가

### DIFF
--- a/Affiliate.ts
+++ b/Affiliate.ts
@@ -8,6 +8,7 @@ import {
   SeasonalOperationTime,
   Location,
 } from './Shop';
+import {CancellationPolicy} from "./Vehicle";
 
 /**
  * @interface Affiliate
@@ -150,4 +151,15 @@ export default interface Affiliate {
    * @default []
    */
   returnGuide: Guide[];
+  /**
+   * @type CancellationPolicy[]
+   * @description 업체의 취소수수료 규정 정보
+   * <br>
+   * 업체 단위로 발생할 수 있는 취소수수료의 정책 정보가 존재할 경우 반환
+   * @nullable true
+   * @required false
+   * @example CancellationPolicy
+   * @default N/A
+   */
+  cancellationPolicies: CancellationPolicy[];
 }


### PR DESCRIPTION
[BACKENDDEV-1878 해외 API 채널별로 지점 별 취소 수수료 데이터를 static 하게 제공할 수 있는 채널들은 업체 조회 시 조회된다](https://teamo2co.atlassian.net/browse/BACKENDDEV-1878) 로,
지점의 취소수수료 규정 정보 프로토콜 구조가 추가되었습니다.