### PR TITLE
FEAT:(BACKENDDEV-3175) cachedCar 도메인 스펙을 Car 도메인과 동일하게 수정

### DIFF
--- a/CachedCar.ts
+++ b/CachedCar.ts
@@ -97,4 +97,38 @@ export interface CachedCar {
    * @default -1
    */
   baggageQuantity: number;
+  /**
+   * @type Boolean
+   * @description 예약된 차량의 에어컨 설치 여부
+   * <br>
+   * 외부에서 제공하는 값이 없다면 null 혹은 false
+   * @nullable true
+   * @required false
+   * @example true
+   * @default false
+   */
+  hasAirCondition: boolean;
+  /**
+   * @type String
+   * @description 예약된 차량의 차종의 변속기
+   * - A/T : 오토
+   * - M/T : 메뉴얼 (수동)
+   * @nullable false
+   * @required true
+   * @example 'A/T'
+   * @default N/A
+   */
+  transmissionType: string;
+  /**
+   * @type Boolean
+   * @description 예약된 차량의 차종 보장 가능 여부
+   * <br>
+   * - true : 항상 이 차종이 보장된다
+   * - false : 다른 차종이 배정될 수 있다.
+   * @nullable false
+   * @required true
+   * @example true
+   * @default N/A
+   */
+  isModelGuaranteed: boolean;
 }


### PR DESCRIPTION
### 작업내용
- cachedCar 에 비필수 데이터 isModelGuaranteed, transmissionType, hasAirCondition 추가
- 운영툴 해외 차량 매칭 시 사용하는 데이터로 차량리스트에서 사용되는 도메인인 Car에서는 포함되어있으나, CachedCar 도메인에서는 포함되어있지 않아 추가했습니다

### 관련 링크
- [JIRA](https://teamo2co.atlassian.net/browse/BACKENDDEV-3175)